### PR TITLE
Add Gemma 3n integration scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# SeeWithMe
+
+SeeWithMe is an experimental React Native application that provides AI‑powered visual assistance. The core vision features are backed by the Gemma 3n on‑device model with a fallback to mocked data for development.
+
+## Features
+
+- **Object & Scene Recognition** – Gemma 3n analyzes camera frames to describe surroundings.
+- **Text-to-Speech Narration** – spoken descriptions are generated on device.
+- **OCR Reader** – reads signs and documents aloud.
+- **Face Recognition & Emotion** – detects familiar faces and basic emotions.
+- **Indoor Navigation Helper** – provides layout and exit guidance.
+- **Multilingual** – results can be translated offline.
+- **Offline First** – all processing runs locally using Gemma 3n.
+- **Voice Commands** – control scanning with simple voice cues.
+
+This repository includes only placeholder calls to Gemma 3n. Implementations should replace the stubs in `components/ai/Gemma3nClient.ts` with real model inference.

--- a/components/ai/Gemma3nClient.ts
+++ b/components/ai/Gemma3nClient.ts
@@ -1,0 +1,29 @@
+// Placeholder Gemma 3n integration
+// In a real environment this would interface with the on-device Gemma 3n model
+// to perform visual analysis, text-to-speech and translation entirely offline.
+import { VisionResult } from './AIVisionService';
+
+export default class Gemma3nClient {
+  async analyze(
+    imageUri: string,
+    mode: 'objects' | 'text' | 'faces' | 'navigation'
+  ): Promise<VisionResult> {
+    // TODO: Replace this stub with actual Gemma 3n model calls
+    return {
+      type: mode,
+      description: 'Gemma analysis placeholder',
+      confidence: 90,
+      timestamp: new Date(),
+      language: 'en',
+    };
+  }
+
+  async textToSpeech(_text: string): Promise<void> {
+    // TODO: Generate audio using Gemma 3n
+  }
+
+  async translate(text: string, _targetLanguage: string): Promise<string> {
+    // TODO: Use Gemma 3n multilingual support
+    return text;
+  }
+}


### PR DESCRIPTION
## Summary
- create `Gemma3nClient` with stubs for object recognition, TTS and translation
- integrate Gemma client into `AIVisionService`
- document Gemma 3n usage in new README

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68624311da5c833084550fd631b46ba9